### PR TITLE
Serve groovy libraries straight from the nix store

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ nix run . -- -s --remote-build
     - jenkinsPlugins2nix
     - Configuration as code
     - Ngrok
-- [x] Associated Groovy libraries
+- [x] Associated Groovy libraries (served from the nix store)
     - cachix push
     - docker push
 - NixOS module: https://github.com/juspay/jenkins-nix-ci/issues/3


### PR DESCRIPTION
Improves #5

This way others can fork this repo and reference their libraries in a self-sufficient manner (rather than referencing incorrectly the upstream repo).