### PR TITLE
Make nixCI and dockerPush $NIX_SYSTEM aware

### DIFF
--- a/nix/jenkins/features/docker/dockerPush.groovy
+++ b/nix/jenkins/features/docker/dockerPush.groovy
@@ -1,6 +1,8 @@
 #!/usr/bin/env groovy
 
 def call(String imagePackageName, String server) {
+    system = env.NIX_SYSTEM
+    nixArgs = system ? "--option system ${system}" : ""
     withCredentials(
         [
           string(credentialsId: 'docker-user', variable: 'DOCKER_USER'),
@@ -9,7 +11,7 @@ def call(String imagePackageName, String server) {
         sh label: "Building and pushing .#${imagePackageName} => registry ${server}",
            script: """
             export DOCKER_SERVER=${server}
-            jenkins-nix-ci-dockerPush ${imagePackageName}
+            jenkins-nix-ci-dockerPush ${imagePackageName} ${nixArgs}
             """
     }
 }

--- a/nix/jenkins/features/docker/dockerPush.nix
+++ b/nix/jenkins/features/docker/dockerPush.nix
@@ -6,12 +6,15 @@ pkgs.writeShellApplication {
   text = ''
     set -euo pipefail
 
+    ARG1="''${1:-start}"
+    shift 1 || true
+
     set -x
     # Do a git status, because the docker tag is based on working copy status
     git status
-    docker load -i "$(nix build ".#$1" --print-out-paths --no-update-lock-file)"
+    docker load -i "$(nix build ".#$ARG1" --print-out-paths --no-update-lock-file "$@")"
     set +x
-    IMAGE_NAME="$(nix eval --json .#packages.x86_64-linux."$1".buildArgs | jq -r '"\(.name):\(.tag)"')"
+    IMAGE_NAME="$(nix eval --json .#packages.x86_64-linux."$ARG1".buildArgs | jq -r '"\(.name):\(.tag)"')"
     echo "Built and loaded: ''${IMAGE_NAME}"
 
     echo "Logging in to Docker Registry"

--- a/nix/jenkins/features/nix/nixCI.groovy
+++ b/nix/jenkins/features/nix/nixCI.groovy
@@ -1,7 +1,8 @@
 #!/usr/bin/env groovy
 
 def call(Map args = [:]) {
-    system = args["system"]
+    // Function args are deprecated
+    system = args["system"] ?: env.NIX_SYSTEM
     stage ("""NixCI (${system ?: "default"})""") {
       nixArgs = [
         system ? "--system ${system}" : "",


### PR DESCRIPTION
Use `NIX_SYSTEM` in Jekinsfile to tell the Groovy scripts which system to build for.

The `system` argument is deprecated.

Resolves #32 automatically